### PR TITLE
add `mainnetNodeConfig2` and allow switching

### DIFF
--- a/lib/node_settings/node_types.dart
+++ b/lib/node_settings/node_types.dart
@@ -8,7 +8,7 @@ import '../spectre/spectre.dart';
 part 'node_types.freezed.dart';
 part 'node_types.g.dart';
 
-const mainnetNodeConfig = NodeConfig(
+const mainnetNodeConfig1 = NodeConfig(
   id: 'd093b14d-da55-4e49-870d-61d63bf201a3',
   name: 'Spectrum Official',
   urls: ['node.spectre-network.org'],
@@ -16,11 +16,20 @@ const mainnetNodeConfig = NodeConfig(
   network: SpectreNetwork.mainnet,
 );
 
+const mainnetNodeConfig2 = NodeConfig(
+  id: '9aee5258-0a32-4731-8a49-360f49c49a72',
+  name: 'Spectrum Official-2',
+  urls: ['node2.spectre-network.xyz'],
+  isSecure: true,
+  network: SpectreNetwork.mainnet,
+);
+
 @freezed
 class NodeConfigSettings with _$NodeConfigSettings {
   const factory NodeConfigSettings({
-    @Default(const IListConst([mainnetNodeConfig])) IList<NodeConfig> options,
-    @Default(mainnetNodeConfig) NodeConfig selected,
+    @Default(IListConst([mainnetNodeConfig1, mainnetNodeConfig2]))
+    IList<NodeConfig> options,
+    @Default(mainnetNodeConfig1) NodeConfig selected,
   }) = _NodeConfigSettings;
 
   factory NodeConfigSettings.fromJson(Map<String, dynamic> json) =>

--- a/lib/node_settings/node_types.dart
+++ b/lib/node_settings/node_types.dart
@@ -24,10 +24,19 @@ const mainnetNodeConfig2 = NodeConfig(
   network: SpectreNetwork.mainnet,
 );
 
+const mainnetNodeConfig3 = NodeConfig(
+  id: '9f2789a2-c055-4e56-8a69-e24f9cf43d28',
+  name: 'Spectrum Official-3',
+  urls: ['node3.spectre-network.xyz'],
+  isSecure: true,
+  network: SpectreNetwork.mainnet,
+);
+
 @freezed
 class NodeConfigSettings with _$NodeConfigSettings {
   const factory NodeConfigSettings({
-    @Default(IListConst([mainnetNodeConfig1, mainnetNodeConfig2]))
+    @Default(IListConst(
+        [mainnetNodeConfig1, mainnetNodeConfig2, mainnetNodeConfig3]))
     IList<NodeConfig> options,
     @Default(mainnetNodeConfig1) NodeConfig selected,
   }) = _NodeConfigSettings;

--- a/lib/settings_advanced/compound_utxos_dialog.dart
+++ b/lib/settings_advanced/compound_utxos_dialog.dart
@@ -73,7 +73,7 @@ class CompoundUtxosDialog extends ConsumerWidget {
 
         UIUtil.showSnackbar(l10n.compoundSuccess, context);
       } catch (e) {
-        UIUtil.showSnackbar(l10n.compoundFailure, context);
+        UIUtil.showSnackbar('${l10n.compoundFailure}: $e', context);
       } finally {
         appRouter.pop(context);
       }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: spectrum
 description: The Ultimate Self-Custodial Wallet for the Spectre Network.
 publish_to: "none"
 
-version: 0.3.20+1
+version: 0.3.21+1
 
 environment:
   sdk: '>=3.3.0 <4.0.0'


### PR DESCRIPTION
* `NodeConfigSettings` class allows to switch between `mainnetNodeConfig1` and `mainnetNodeConfig2` by updating the `selected` field. When selected configuration changes, `ActiveNodeConfig` automatically updates related properties.
* re-enable debug compound error (disabled by mistake previously)
---
* added additional `mainnetNodeConfig3`