### PR TITLE
fix TxIndex order, sigopcount and selective refresh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         run: dart format --output=none .
 
       - name: Analyze Dart Code
-        run: dart analyze
+        run: dart analyze --no-fatal-warnings
 
       - name: Run Flutter Tests
         run: flutter test

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 MIT License
 
-Copyright (c) 2021 Kaspium Wallet authors
-Copyright (c) 2024 Spectre Network developers
+Copyright (c) 2018-2021 Appditto LLC, 2022-2025 Kaspium Wallet authors
+Copyright (c) 2024-2025 Spectre Network developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/lib/spectre/spectre_api/types.dart
+++ b/lib/spectre/spectre_api/types.dart
@@ -94,6 +94,16 @@ class ApiTxId with _$ApiTxId {
       _$ApiTxIdFromJson(json);
 }
 
+int _sigOpCountFromJson(sigOpCount) {
+  if (sigOpCount is int) {
+    return sigOpCount;
+  }
+  if (sigOpCount is String) {
+    return int.tryParse(sigOpCount) ?? 0;
+  }
+  return 0;
+}
+
 @freezed
 class ApiTxInput with _$ApiTxInput {
   @JsonSerializable(fieldRename: FieldRename.snake)
@@ -103,7 +113,7 @@ class ApiTxInput with _$ApiTxInput {
     required String previousOutpointHash,
     required BigInt previousOutpointIndex,
     required String signatureScript,
-    required BigInt sigOpCount,
+    @JsonKey(fromJson: _sigOpCountFromJson) required int sigOpCount,
     // new fields
     String? previousOutpointAddress,
     int? previousOutpointAmount,
@@ -160,7 +170,7 @@ class ApiTransaction with _$ApiTransaction {
           previousOutpointHash: e.previousOutpoint.transactionId,
           previousOutpointIndex: BigInt.from(e.previousOutpoint.index),
           signatureScript: e.signatureScript,
-          sigOpCount: BigInt.from(e.sigOpCount),
+          sigOpCount: e.sigOpCount,
         );
       }).toList(),
       outputs: tx.outputs.mapIndexed((index, e) {
@@ -175,4 +185,6 @@ class ApiTransaction with _$ApiTransaction {
       }).toList(),
     );
   }
+
+  bool get isCoinbase => inputs.isEmpty;
 }

--- a/lib/transactions/transaction_notifier.dart
+++ b/lib/transactions/transaction_notifier.dart
@@ -200,4 +200,29 @@ class TransactionNotifier extends SafeChangeNotifier {
 
     return refreshAddresses.toIList();
   }
+
+  Future<void> checkForMissingTxs(Iterable<String> tdIds) async {
+    if (tdIds.isEmpty) {
+      return;
+    }
+
+    final missingTxs = <String>{};
+    for (final txId in tdIds) {
+      if (!cache.isWalletTxId(txId)) {
+        missingTxs.add(txId);
+      }
+    }
+
+    if (missingTxs.isEmpty) {
+      return;
+    }
+
+    final txs = await api.getTxsWithIds(missingTxs);
+    if (txs.isEmpty) {
+      return;
+    }
+    await cache.cacheWalletTxs(txs);
+
+    await reload();
+  }
 }

--- a/lib/transactions/transaction_providers.dart
+++ b/lib/transactions/transaction_providers.dart
@@ -127,6 +127,12 @@ final txNotifierForWalletProvider = ChangeNotifierProvider.autoDispose
     notifier.fetchNewTxsForAddresses(next.keys);
   }, fireImmediately: true);
 
+  // Check for missing transactions in UTXOs
+  ref.listen(utxoListProvider, (_, utxos) {
+    notifier.checkForMissingTxs(
+        utxos.take(100).map((u) => u.outpoint.transactionId));
+  }, fireImmediately: true);
+
   // Cache new transactions
   ref.listen(_newTransactionProvider, (_, next) {
     if (next.asData?.value case final tx?) {

--- a/lib/transactions/tx_cache_service.dart
+++ b/lib/transactions/tx_cache_service.dart
@@ -65,7 +65,7 @@ class TxCacheService {
   }
 
   // Builds a Tx object from an ApiTransaction object using cached input txs
-  Tx _txForApiTx(ApiTransaction apiTx, {int? lastUpdate}) {
+  Tx _txForApiTx(ApiTransaction apiTx) {
     final inputs = apiTx.inputs.map((input) {
       // use new available input amount and address from apiTx
       if (input.previousOutpointAmount != null &&
@@ -93,7 +93,7 @@ class TxCacheService {
     final tx = Tx(
       apiTx: apiTx,
       inputData: inputs,
-      lastUpdate: lastUpdate ?? _refreshTimestamp,
+      lastUpdate: _refreshTimestamp,
     );
 
     return tx;
@@ -148,14 +148,16 @@ class TxCacheService {
   Future<Tx> addWalletTx(ApiTransaction apiTx) async {
     addToMemcache(apiTx);
 
+    final txIndex = TxIndex(
+      txId: apiTx.transactionId,
+      blockTime: apiTx.blockTime,
+    );
+    await _txIndex.add(txIndex);
+
     await _cacheInputsFor([apiTx]);
 
     final tx = _txForApiTx(apiTx);
-
     await txBox.set(tx.id, tx);
-
-    final txIndex = TxIndex(txId: tx.id, blockTime: tx.apiTx.blockTime);
-    await _txIndex.add(txIndex);
 
     return tx;
   }
@@ -166,7 +168,9 @@ class TxCacheService {
     final delta = Duration(seconds: 100).inMilliseconds;
     final notFresh = _refreshTimestamp > tx.lastUpdate + 3000;
     final needsRefresh = tx.lastUpdate < tx.apiTx.blockTime + delta;
-    return notFresh && needsRefresh;
+    return notFresh &&
+        needsRefresh &&
+        (!tx.apiTx.isAccepted || tx.apiTx.isCoinbase);
   }
 
   Future<Iterable<Tx>> getWalletTxsAfter({String? txId, int count = 10}) async {

--- a/lib/widgets/app_simpledialog.dart
+++ b/lib/widgets/app_simpledialog.dart
@@ -78,7 +78,7 @@ class Dialog extends StatelessWidget {
           borderRadius: BorderRadius.all(Radius.circular(4.0)));
   @override
   Widget build(BuildContext context) {
-    final DialogTheme dialogTheme = DialogTheme.of(context);
+    final dialogTheme = DialogTheme.of(context);
     return AnimatedPadding(
       padding: MediaQuery.of(context).viewInsets +
           const EdgeInsets.symmetric(horizontal: 20.0, vertical: 20.0),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,7 +55,7 @@ dependencies:
   protobuf: 3.1.0
   grpc: 4.0.1
   hex: 0.2.0
-  collection: 1.18.0
+  collection: ^1.18.0
   fixnum: 1.1.0
   pointycastle: ^3.9.1
   flutter_portal: 1.1.4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: spectrum
 description: The Ultimate Self-Custodial Wallet for the Spectre Network.
 publish_to: "none"
 
-version: 0.3.21+1
+version: 0.3.22+1
 
 environment:
   sdk: '>=3.3.0 <4.0.0'


### PR DESCRIPTION
- fix sigOpCount
- optimize transaction refresh: fix TxIndex creation order and only refresh unaccepted/coinbase transactions
- add `checkForMissingTxs()` to get missing UTXO transactions
- lints
- version bump to `0.3.22`